### PR TITLE
Allow anchor links in summary points

### DIFF
--- a/admin/class-summaraize-admin-metabox.php
+++ b/admin/class-summaraize-admin-metabox.php
@@ -195,9 +195,21 @@ class Summaraize_Admin_Metabox {
 		}
 
 		// Save 'summaraize_points' directly if set.
-		if ( isset( $_POST['summaraize_points'] ) && is_array( $_POST['summaraize_points'] ) ) {
-			// Sanitize each point.
-			$summaraize_points = array_map( 'sanitize_text_field', wp_unslash( $_POST['summaraize_points'] ) );
+               if ( isset( $_POST['summaraize_points'] ) && is_array( $_POST['summaraize_points'] ) ) {
+                       // Sanitize each point while allowing anchor tags.
+                       $allowed_tags     = array(
+                               'a' => array(
+                                       'href'   => array(),
+                                       'target' => array(),
+                                       'rel'    => array(),
+                               ),
+                       );
+                       $summaraize_points = array_map(
+                               function ( $point ) use ( $allowed_tags ) {
+                                       return wp_kses( wp_unslash( $point ), $allowed_tags );
+                               },
+                               $_POST['summaraize_points']
+                       );
 
 			// Optionally, remove empty points.
 			$summaraize_points = array_filter( $summaraize_points, 'strlen' );

--- a/admin/class-summaraize-admin-settings.php
+++ b/admin/class-summaraize-admin-settings.php
@@ -664,8 +664,20 @@ class Summaraize_Admin_Settings {
 			wp_send_json_error( array( 'message' => __( 'Invalid points data.', 'summaraize' ) ) );
 		}
 
-		// Sanitize each point in the array..
-		$sanitized_points = array_map( 'sanitize_text_field', $sorted_points );
+               // Sanitize each point in the array while allowing anchor tags..
+               $allowed_tags    = array(
+                       'a' => array(
+                               'href'   => array(),
+                               'target' => array(),
+                               'rel'    => array(),
+                       ),
+               );
+               $sanitized_points = array_map(
+                       function ( $point ) use ( $allowed_tags ) {
+                               return wp_kses( $point, $allowed_tags );
+                       },
+                       $sorted_points
+               );
 
 		// Save the sorted points as post meta.
 		if ( update_post_meta( $post_id, 'summaraize_points', $sanitized_points ) ) {

--- a/public/class-summaraize-public.php
+++ b/public/class-summaraize-public.php
@@ -177,11 +177,18 @@ class Summaraize_Public {
 			echo '<h2>' . esc_html( $widget_title ) . '</h2>';
 
 			// Choose list type.
-			echo ( 'ordered' === $list_type ) ? '<ol>' : '<ul>';
-			foreach ( $summaraize_points as $point ) {
-				echo '<li>' . esc_html( $point ) . '</li>';
-			}
-			echo ( 'ordered' === $list_type ) ? '</ol>' : '</ul>';
+                       echo ( 'ordered' === $list_type ) ? '<ol>' : '<ul>';
+                       foreach ( $summaraize_points as $point ) {
+                               $allowed_tags = array(
+                                       'a' => array(
+                                               'href'   => array(),
+                                               'target' => array(),
+                                               'rel'    => array(),
+                                       ),
+                               );
+                               echo '<li>' . wp_kses( $point, $allowed_tags ) . '</li>';
+                       }
+                       echo ( 'ordered' === $list_type ) ? '</ol>' : '</ul>';
 
 			echo '</div>';
 			echo '</div>';
@@ -191,11 +198,18 @@ class Summaraize_Public {
 			echo '<h2>' . esc_html( $widget_title ) . '</h2>';
 
 			// Choose list type.
-			echo ( 'ordered' === $list_type ) ? '<ol>' : '<ul>';
-			foreach ( $summaraize_points as $point ) {
-				echo '<li>' . esc_html( $point ) . '</li>';
-			}
-			echo ( 'ordered' === $list_type ) ? '</ol>' : '</ul>';
+                       echo ( 'ordered' === $list_type ) ? '<ol>' : '<ul>';
+                       foreach ( $summaraize_points as $point ) {
+                               $allowed_tags = array(
+                                       'a' => array(
+                                               'href'   => array(),
+                                               'target' => array(),
+                                               'rel'    => array(),
+                                       ),
+                               );
+                               echo '<li>' . wp_kses( $point, $allowed_tags ) . '</li>';
+                       }
+                       echo ( 'ordered' === $list_type ) ? '</ol>' : '</ul>';
 
 			echo '</div>';
 		}


### PR DESCRIPTION
## Summary
- allow `<a>` links in saved summary points
- sanitize HTML with `wp_kses`
- permit links when reordering points via AJAX
- output points with allowed anchor tags

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run check` *(fails: phpcs not found)*
- `npm run phpmd` *(fails: phpmd not found)*

------
https://chatgpt.com/codex/tasks/task_e_686957b97a68832fa4b3fbbb19c32ce5